### PR TITLE
Update PyPI package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ allows you to work with Onedata in the same way as any other supported filesyste
 You can install OnedataRESTFS from pip as follows:
 
 ```
-pip install onedatarestfs
+pip install fs.onedatarestfs
 ```
 
 ## Opening a OnedataRESTFS


### PR DESCRIPTION
There does not appear to be a PyPI package named onedatarestfs. Have updated based on: https://github.com/galaxyproject/galaxy/pull/16690/